### PR TITLE
chore: possible LSP configs was moved

### DIFF
--- a/content/fr/tech/20240705-neovim-tutoriel-ide-a-partir-de-zero.md
+++ b/content/fr/tech/20240705-neovim-tutoriel-ide-a-partir-de-zero.md
@@ -1067,7 +1067,7 @@ return {
     mason_lspconfig.setup({
       automatic_enable = true,
       -- Liste des serveurs à installer par défaut
-      -- List des serveurs possibles : https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md
+      -- List des serveurs possibles : https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md
       -- Vous pouvez ne pas en mettre ici et tout installer en utilisant :Mason
       -- Mais au lieu de passer par :Mason pour installer, je vous recommande d'ajouter une entrée à cette liste
       -- Ça permettra à votre configuration d'être plus portable


### PR DESCRIPTION
L'ancienne page: "This file was renamed to [configs.md](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md)."